### PR TITLE
Fixing data racing proposal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     working_dir: /go/src/github.com/gemnasium/logrus-postgresql-hook
     volumes:
       - $GOPATH:/go
-    command: sh -c 'go get -t -v ./... && go test -v ./...'
+    command: sh -c 'go get -t -v ./... && go test -race -v ./...'
     links:
       - postgres
   postgres:

--- a/postgresql_hook.go
+++ b/postgresql_hook.go
@@ -74,7 +74,7 @@ func NewAsyncHook(db *sql.DB, extra map[string]interface{}) *AsyncHook {
 		Hook:       NewHook(db, extra),
 		buf:        make(chan *logrus.Entry, BufSize),
 		flush:      make(chan bool),
-		Ticker:     time.NewTicker(time.Second),
+		Ticker:     time.NewTicker(300 * time.Millisecond),
 		InsertFunc: asyncInsertFunc,
 	}
 	go hook.fire() // Log in background
@@ -169,7 +169,6 @@ func (hook *Hook) Blacklist(b []string) {
 // Flush waits for the log queue to be empty.
 // This func is meant to be used when the hook was created with NewAsyncHook.
 func (hook *AsyncHook) Flush() {
-	hook.Ticker = time.NewTicker(100 * time.Millisecond)
 	hook.wg.Wait()
 	hook.flush <- true
 	<-hook.flush

--- a/postgresql_hook_test.go
+++ b/postgresql_hook_test.go
@@ -47,10 +47,6 @@ func TestHooks(t *testing.T) {
 			log.Level = logrus.DebugLevel
 			log.Hooks.Add(hook)
 
-			if h, ok := hook.(*AsyncHook); ok {
-				h.Ticker = time.NewTicker(100 * time.Millisecond)
-			}
-
 			// Purge our test DB
 			_, err = db.Exec("delete from logs;")
 			if err != nil {


### PR DESCRIPTION
Probably even setting the ticker to `100 * time.Millisecond` would be ok for the DB as in `normal` use-cases the log messages are generated only in specific parts of the code or for specific actions. What do you think?

Fixes #9 